### PR TITLE
Feat docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Dependencies
+node_modules
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+venv/
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Development files
+.git
+.gitignore
+.vscode
+.idea
+*.swp
+*.swo
+
+# Build and cache
+dist
+build
+*.egg-info/
+.eggs/
+.pytest_cache/
+.coverage
+coverage.xml
+*.log
+npm-debug.log*
+
+# Documentation
+README.md
+DOCS.md
+LICENSE
+
+# Test files
+tests/
+test/
+__tests__/
+
+# Other
+.DS_Store
+Demostracion.mp4

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Archivo que maneja diferentes entornos:
 
 ## 🔧 Instalación y Uso
 
+### Desarrollo Local
+
 1. **Requisitos previos**
    - Node.js 18.x
    - Python 3.10+
@@ -88,9 +90,38 @@ npm run dev
 4. **Ejecución conjunta** (usando Concurrently):
 ```bash
 npm install -g concurrently
-
 npm run start
 ```
+
+### Desarrollo con Docker para desarrollo (reload)
+
+1. **Requisitos previos**
+   - Docker
+   - Docker Compose
+
+2. **Configuración**
+   - Copia el archivo `.env.example` a `.env` en la raíz del proyecto
+   - Ajusta las variables de entorno según sea necesario
+
+3. **Construcción y ejecución**
+```bash
+# Construir y levantar los contenedores
+docker-compose -f docker-compose.dev.yml up --build
+
+# Ejecutar en segundo plano
+docker-compose -f docker-compose.dev.yml up -d
+
+# Detener los contenedores
+docker-compose -f docker-compose.dev.yml down
+```
+
+4. **Acceso**
+   - Frontend: http://localhost:5173
+   - Backend API: http://localhost:8000
+
+5. **Desarrollo**
+   - Los cambios en el código se reflejan automáticamente gracias a los volúmenes montados
+   - Hot-reloading está habilitado tanto en frontend como en backend
 ## 🏛️ Arquitectura y Patrones
 
 ### Backend (FastAPI)

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,13 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,22 +1,32 @@
 import json
 from pathlib import Path
+from typing import Optional
 from pydantic import BaseSettings
 
 def load_config():
     config_path = Path(__file__).parent.parent.parent.parent / 'config.json'
-    with open(config_path) as f:
-        return json.load(f)
+    try:
+        with open(config_path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {
+            "development": {
+                "frontend": {"url": "http://localhost:5173"},
+                "backend": {"host": "http://localhost:8000", "port": 8000}
+            }
+        }
 
 config = load_config()
 env_config = config['development']
 
 class Settings(BaseSettings):
-    API_PORT: int = env_config['backend']['port']
+    API_PORT: int = int(env_config['backend']['port'])
     API_HOST: str = env_config['backend']['host']
     ENVIRONMENT: str = "development"
     FRONTEND_URL: str = env_config['frontend']['url']
 
     class Config:
         env_file = ".env"
+        case_sensitive = True
 
 settings = Settings()

--- a/config.json
+++ b/config.json
@@ -8,5 +8,15 @@
       "host": "http://localhost:8000",
       "port": 8000
     }
+  },
+  "production": {
+    "frontend": {
+      "url": "http://localhost:5173",
+      "api_url": "http://localhost:8000/api"
+    },
+    "backend": {
+      "host": "http://localhost:8000",
+      "port": 8000
+    }
   }
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - ./config.json:/app/config.json
+    ports:
+      - "5173:5173"
+    environment:
+      - VITE_API_URL=${VITE_API_URL}
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+    environment:
+      - ENVIRONMENT=development
+      - HOST=${BACKEND_HOST:-0.0.0.0}
+      - PORT=${BACKEND_PORT:-8000}

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+COPY config.json /app/config.json
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,4 +1,4 @@
-import config from '../../config.json';
+import config from '@config';
 
 type Environment = 'development' | 'production';
 
@@ -16,7 +16,7 @@ type ConfigType = {
   };
 };
 
-const env = import.meta.env.MODE as Environment;
+const env = (import.meta.env.VITE_ENV || import.meta.env.MODE) as Environment;
 export const CONFIG = (config as ConfigType)[env];
 
-export const API_URL = CONFIG.frontend.api_url;
+export const API_URL = import.meta.env.VITE_API_URL || CONFIG.frontend.api_url;

--- a/frontend/src/types/config.d.ts
+++ b/frontend/src/types/config.d.ts
@@ -1,0 +1,27 @@
+declare module '@config' {
+  interface Config {
+    development: {
+      frontend: {
+        url: string;
+        api_url: string;
+      };
+      backend: {
+        host: string;
+        port: number;
+      };
+    };
+    production: {
+      frontend: {
+        url: string;
+        api_url: string;
+      };
+      backend: {
+        host: string;
+        port: number;
+      };
+    };
+  }
+
+  const config: Config;
+  export default config;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [
@@ -13,4 +14,10 @@ export default defineConfig({
   define: {
     'process.env': {},
   },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      '@config': resolve(__dirname, '../config.json')
+    }
+  }
 });


### PR DESCRIPTION
Agrega configuración Docker para el monorepo  

### **Descripción:**  
- Se añade la configuración de **Docker** para el monorepo.  
- Se incluyen los archivos `Dockerfile` y `.dockerignore`.  
- Se configuran los servicios en `docker-compose.dev.yml`.  
- Se ajustan las variables de entorno para compatibilidad con Docker.  
- Se optimiza la cache en la construcción de imágenes para mejorar tiempos de despliegue.  

### **Cómo probar:**  
1. Asegúrate de tener **Docker** y **Docker Compose** instalados.  
2. Corre `docker compose -f docker-compose-dev up ` para levantar los servicios.  
3. Verifica que la API responde correctamente en `http://localhost:5173/`.  

### **Notas adicionales:**  
- Se documentó en el `README.md` cómo usar Docker con este monorepo.  